### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/queries/__init__.py
+++ b/queries/__init__.py
@@ -64,10 +64,10 @@ def uri(host='localhost', port=5432, dbname='postgres', user='postgres',
 
     """
     if port:
-        host = '%s:%s' % (host, port)
+        host = '{0!s}:{1!s}'.format(host, port)
     if password:
-        return 'postgresql://%s:%s@%s/%s' % (user, password, host, dbname)
-    return 'postgresql://%s@%s/%s' % (user, host, dbname)
+        return 'postgresql://{0!s}:{1!s}@{2!s}/{3!s}'.format(user, password, host, dbname)
+    return 'postgresql://{0!s}@{1!s}/{2!s}'.format(user, host, dbname)
 
 
 # For ease of access to different cursor types

--- a/queries/pool.py
+++ b/queries/pool.py
@@ -418,7 +418,7 @@ class PoolManager(object):
 
         """
         if pid in cls._pools:
-            raise KeyError('Pool %s already exists' % pid)
+            raise KeyError('Pool {0!s} already exists'.format(pid))
         with cls._lock:
             LOGGER.debug("Creating Pool: %s (%i/%i)", pid, idle_ttl, max_size)
             cls._pools[pid] = Pool(pid, idle_ttl, max_size)
@@ -581,7 +581,7 @@ class PoolManager(object):
 
         """
         if pid not in cls._pools:
-            raise KeyError('Pool %s has not been created' % pid)
+            raise KeyError('Pool {0!s} has not been created'.format(pid))
 
 
 class ConnectionException(Exception):
@@ -603,28 +603,28 @@ class PoolConnectionException(Exception):
 class ActivePoolError(PoolException):
     """Raised when removing a pool that has active connections"""
     def __str__(self):
-        return 'Pool %s has at least one active connection' % self.pid
+        return 'Pool {0!s} has at least one active connection'.format(self.pid)
 
 
 class ConnectionBusyError(ConnectionException):
     """Raised when trying to lock a connection that is already busy"""
     def __str__(self):
-        return 'Connection %s is busy' % self.cid
+        return 'Connection {0!s} is busy'.format(self.cid)
 
 
 class ConnectionNotFoundError(PoolConnectionException):
     """Raised if a specific connection is not found in the pool"""
     def __str__(self):
-        return 'Connection %s not found in pool %s' % (self.cid, self.pid)
+        return 'Connection {0!s} not found in pool {1!s}'.format(self.cid, self.pid)
 
 
 class NoIdleConnectionsError(PoolException):
     """Raised if a pool does not have any idle, open connections"""
     def __str__(self):
-        return 'Pool %s has no idle connections' % self.pid
+        return 'Pool {0!s} has no idle connections'.format(self.pid)
 
 
 class PoolFullError(PoolException):
     """Raised when adding a connection to a pool that has hit max-size"""
     def __str__(self):
-        return 'Pool %s is at its maximum capacity' % self.pid
+        return 'Pool {0!s} is at its maximum capacity'.format(self.pid)

--- a/queries/results.py
+++ b/queries/results.py
@@ -60,7 +60,7 @@ class Results(object):
         return bool(self.cursor.rowcount)
 
     def __repr__(self):
-        return '<queries.%s rows=%s>' % (self.__class__.__name__, len(self))
+        return '<queries.{0!s} rows={1!s}>'.format(self.__class__.__name__, len(self))
 
     def as_dict(self):
         """Return a single row result as a dictionary. If the results contain

--- a/queries/tornado_session.py
+++ b/queries/tornado_session.py
@@ -446,7 +446,7 @@ class TornadoSession(session.Session):
             self._ioloop.remove_handler(fd)
             if fd in self._futures and not self._futures[fd].done():
                 self._futures[fd].set_exception(
-                    psycopg2.OperationalError('Connection error (%s)' % error)
+                    psycopg2.OperationalError('Connection error ({0!s})'.format(error))
                 )
         except (psycopg2.Error, psycopg2.Warning) as error:
             if fd in self._futures and not self._futures[fd].done():

--- a/queries/utils.py
+++ b/queries/utils.py
@@ -106,7 +106,7 @@ def urlparse(url):
     :rtype: Parsed
 
     """
-    value = 'http%s' % url[5:] if url[:5] == 'postgresql' else url
+    value = 'http{0!s}'.format(url[5:]) if url[:5] == 'postgresql' else url
     parsed = _urlparse.urlparse(value)
 
     # Python 2.6 hack

--- a/tests/pool_exception_tests.py
+++ b/tests/pool_exception_tests.py
@@ -22,7 +22,7 @@ class ActivePoolErrorTestCase(unittest.TestCase):
         self.assertEqual(self.exception.pid, self.pid)
 
     def test_str_value(self):
-        expectation = 'Pool %s has at least one active connection' % self.pid
+        expectation = 'Pool {0!s} has at least one active connection'.format(self.pid)
         self.assertEqual(str(self.exception), expectation)
 
 
@@ -36,7 +36,7 @@ class ConnectionBusyErrorTestCase(unittest.TestCase):
         self.assertEqual(self.exception.cid, self.cid)
 
     def test_str_value(self):
-        expectation = 'Connection %s is busy' % self.cid
+        expectation = 'Connection {0!s} is busy'.format(self.cid)
         self.assertEqual(str(self.exception), expectation)
 
 
@@ -54,7 +54,7 @@ class ConnectionNotFoundErrorTestCase(unittest.TestCase):
         self.assertEqual(self.exception.pid, self.pid)
 
     def test_str_value(self):
-        expectation = 'Connection %s not found in pool %s' % (self.cid,
+        expectation = 'Connection {0!s} not found in pool {1!s}'.format(self.cid,
                                                               self.pid)
         self.assertEqual(str(self.exception), expectation)
 
@@ -69,7 +69,7 @@ class NoIdleConnectionsErrorTestCase(unittest.TestCase):
         self.assertEqual(self.exception.pid, self.pid)
 
     def test_str_value(self):
-        expectation = 'Pool %s has no idle connections' % self.pid
+        expectation = 'Pool {0!s} has no idle connections'.format(self.pid)
         self.assertEqual(str(self.exception), expectation)
 
 
@@ -83,5 +83,5 @@ class PoolFullErrorTestCase(unittest.TestCase):
         self.assertEqual(self.exception.pid, self.pid)
 
     def test_str_value(self):
-        expectation = 'Pool %s is at its maximum capacity' % self.pid
+        expectation = 'Pool {0!s} is at its maximum capacity'.format(self.pid)
         self.assertEqual(str(self.exception), expectation)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:queries?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:queries?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
